### PR TITLE
Use Terraforming v0.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ WORKDIR /app
 COPY Gemfile /app/
 COPY Gemfile.lock /app/
 
-RUN apk add --no-cache --update g++ make \
+RUN apk add --no-cache --update --virtual .build-deps \
+      g++ make \
     && bundle install -j4 --without test development --system \
-    && apk del g++ make
+    && apk del .build-deps
 
 CMD ["terraforming", "help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ruby:2.3.1-alpine
-MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 
 RUN bundle config --global frozen 1
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "terraforming", "0.8.0"
+gem "terraforming", "0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.3.9)
-      aws-sdk-resources (= 2.3.9)
-    aws-sdk-core (2.3.9)
+    aws-sdk (2.6.43)
+      aws-sdk-resources (= 2.6.43)
+    aws-sdk-core (2.6.43)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.9)
-      aws-sdk-core (= 2.3.9)
-    jmespath (1.2.4)
-      json_pure (>= 1.8.1)
-    json_pure (1.8.3)
-    oj (2.15.1)
-    ox (2.4.1)
-    terraforming (0.8.0)
-      aws-sdk (~> 2.3.0)
-      oj (~> 2.15.0)
-      ox (~> 2.4.0)
+    aws-sdk-resources (2.6.43)
+      aws-sdk-core (= 2.6.43)
+    aws-sigv4 (1.0.0)
+    jmespath (1.3.1)
+    multi_json (1.12.1)
+    terraforming (0.12.0)
+      aws-sdk (~> 2.6.1)
+      multi_json (~> 1.12.1)
       thor
-    thor (0.19.1)
+    thor (0.19.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  terraforming (= 0.8.0)
+  terraforming (= 0.12.0)
 
 BUNDLED WITH
-   1.12.0
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Please see [Terraforming Github repository](https://github.com/dtan4/terraformin
 
 - `latest`
   - Ruby 2.3.1
-  - Terraforming 0.8.0 [![Gem Version](https://badge.fury.io/rb/terraforming.svg)](http://badge.fury.io/rb/terraforming)
-
+  - Terraforming 0.12.0
 
 ## Usage
 

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-TERRAFORMING_VERSION="0.8.0"
+TERRAFORMING_VERSION="0.12.0"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
Close #24 

## WHY

The current latest version of Terraforming is v0.12.0. However, I forgot to update this Docker image for over half a year...

## WHAT

Use the latest Terraforming.